### PR TITLE
Merge agahkarakuzu's changes upstream

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-# Container image that runs your code
-FROM mtmiller/octave
+# It comes with packages installed Octave 4.2.2
+FROM qmrlab/octaveci:v4.2.2
 
-RUN git clone https://github.com/MOxUnit/MOxUnit.git /home/MOxUnit
-RUN git clone https://github.com/MOdox/MOdox.git /home/MOdox
-RUN git clone https://github.com/MOcov/MOcov.git /home/MOcov
+RUN git clone https://github.com/MOxUnit/MOxUnit.git /home/MOxUnit; \
+    git clone https://github.com/MOdox/MOdox.git /home/MOdox; \
+    git clone https://github.com/MOcov/MOcov.git /home/MOcov 
 
 # Copies your code file from your action repository to the filesystem path `/` of the container
 COPY entrypoint.sh /entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -8,6 +8,21 @@
 
 This action performs unit tests for GNU Octave and Matlab using the unit testing framework [MOxUnit](https://github.com/MOxUnit/MOxUnit). Documentation tests and coverage reports are supported via [MOdox](https://github.com/MOdox/MOdox) and [MOCov](https://github.com/MOcov/MOcov).
 
+## Container
+
+This action uses `qmarlab/octaveci:4.2.2` that contains following packages/versions:
+
+```
+Package Name  | Version | Installation directory
+--------------+---------+-----------------------
+       image  |   2.6.2 | /usr/share/octave/packages/image-2.6.2
+          io  |  2.4.10 | /usr/share/octave/packages/io-2.4.10
+       optim  |   1.5.2 | /usr/share/octave/packages/optim-1.5.2
+    parallel  |   3.1.1 | /usr/share/octave/packages/parallel-3.1.1
+  statistics  |   1.3.0 | /usr/share/octave/packages/statistics-1.3.0
+      struct  |  1.0.14 | /usr/share/octave/packages/struct-1.0.14
+```
+
 ## Usage
 
 In the simplest case
@@ -41,6 +56,9 @@ steps:
 | - | - | - |
 | `tests` | files or directories containing the MOxUnit test cases | *Optional*, defaults to the root directory of the repo. All subdirectories are added recursively. |
 | `src` | directories to be added to the Octave search path before running the tests. These directories will be considered in the coverage reports, if coverage is enabled. | *Optional*
+| `data` | Directory for test data | *Optional* |
+| `pkg` | Octave packages to load. Available options: `image` `io` `optim` `parallel` `statistics` `struct`| *Optional* |
+| `ext` | External resources to add to the search put (excluded from coverage)| *Optional* |
 | `log_file` | store the output in file output | *Optional* |
 | `doc_tests` | set to `true` to run documentation tests with [MOdox](https://github.com/MOdox/MOdox) | *Optional* |
 | `with_coverage` | set to `true` to record coverage using [MOCov](https://github.com/MOcov/MOcov) | *Optional* |

--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ name: 'MOxUnit Action'
 description: 'Run unittests for Matlab/Octave using MOxUnit'
 inputs:
   tests:
-    description: 'directory containing the MOxUnit test cases'
+    description: 'directory containing the MOxUnit test cases'   
   src:
     description: 'directory of the source code'
   log_file:
@@ -20,7 +20,13 @@ inputs:
     description: 'store test results in junit XML file'
   cover_json_file:
     description: 'store coverage report in json file for  processing by coveralls.io'
-  
+  data:
+    description: 'directory containing the test data' 
+  pkg:
+    description: 'list of Octave packages to load (image, io, optim, parallel, statistics, struct)'   
+  ext:
+    description: 'other directories e.g. external dependencies'
+    
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -34,6 +40,9 @@ runs:
     - ${{ inputs.cover_html_dir }}
     - ${{ inputs.cover_junit_xml_file }}
     - ${{ inputs.cover_json_file }}
+    - ${{ inputs.data }}
+    - ${{ inputs.pkg }}
+    - ${{ inputs.ext }}
 
 branding:
   icon: check-circle

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,6 +10,9 @@ COVER_XML_FILE=$6
 COVER_HTML_DIR=$7
 COVER_JUNIT_XML_FILE=$8
 COVER_JSON_FILE=$9
+DATA=$10
+PKG=$11
+EXT=$12
 
 # Create an Octave expression to set up the environment
 SETUP=""
@@ -18,6 +21,7 @@ SETUP=""
 SETUP="$SETUP addpath(\"/home/MOxUnit/MOxUnit\");"
 SETUP="$SETUP addpath(\"/home/MOdox/MOdox\");"
 SETUP="$SETUP addpath(\"/home/MOcov/MOcov\");"
+SETUP="$SETUP setenv(\"PLATFORM\",\"GITHUB_ACTIONS\");"
 SETUP="$SETUP moxunit_set_path();"
 
 # add src directories to the path
@@ -33,6 +37,35 @@ if ! [ -z $SRC ] ; then
 else
   # This is used for coverage and documentation tests
   SRC_DIRS="'.'"
+fi
+
+
+if [ -z $DATA ] ; then
+  DATA=""
+else
+   SETUP="$SETUP addpath(\"$PWD/$DATA\");"
+   echo "TEST DATA DIR: $PWD/$DATA"
+   ls $PWD/$DATA
+fi
+
+if [ -z $EXT ] ; then
+  EXT=""
+else
+   SETUP="$SETUP addpath(genpath(\"$PWD/$EXT\"));"
+fi
+
+
+# Load Octave packages 
+if [ -z $PKG ] ; then
+  DATA=""
+else
+  PKG_LIST=""
+  for pkg_name in $PKG
+  do 
+    PKG_LIST="$PKG_LIST pkg load $pkg_name;"
+  done
+
+  SETUP="$SETUP $PKG_LIST pkg list;"
 fi
 
 ###########################


### PR DESCRIPTION
 - Use qmrlab/octaveci:v4.2.2 instead of mtmiller/octave as base docker image
 - Add optional test data directory
 - Add option to install octave packages
 - Add option to add external packages to the search path

Co-authored-by: Agah <agahkarakuzu@gmail.com>